### PR TITLE
fix cell button being selected on multiple cells bug: retrieve and se…

### DIFF
--- a/plusOne/View/UserPollCell.swift
+++ b/plusOne/View/UserPollCell.swift
@@ -98,9 +98,21 @@ class UserPollCell: UITableViewCell {
         self.poll = poll
         self.statementText.text = poll.statement
         self.numOfUserReactedText.text = "\(poll.reactions) Users Reacted"
-    
         
- 
+        // retrieves and sets the cell's buttons state
+        // this is an int of 0 or 1
+        switch self.choice?.userChoice {
+        case nil:
+            relateBtn.isEnabled = true
+            notRelateBtn.isEnabled = true
+            break
+        case 0:
+            notRelateBtn.isEnabled = false
+            relateBtn.isEnabled = true
+        default:
+            relateBtn.isEnabled = false
+            notRelateBtn.isEnabled = true
+        }
     }
 
 }


### PR DESCRIPTION
…t cells' button state for choices so that each cells' button will only affect the one selected

https://stackoverflow.com/questions/52161786/uitableview-custom-cell-button-selects-other-buttons-out-of-the-main-view